### PR TITLE
fix require path for helpers

### DIFF
--- a/lib/reap-worker.js
+++ b/lib/reap-worker.js
@@ -1,4 +1,4 @@
-var helpers = require('session-file-helpers');
+var helpers = require('./session-file-helpers');
 
 var options = helpers.defaults({
   path: process.argv[2],

--- a/lib/session-file-store.js
+++ b/lib/session-file-store.js
@@ -1,4 +1,4 @@
-var helpers = require('session-file-helpers');
+var helpers = require('./session-file-helpers');
 
 /**
  * https://github.com/expressjs/session#session-store-implementation

--- a/test/store.js
+++ b/test/store.js
@@ -1,0 +1,13 @@
+var session = function() {};
+session.Store = function() {};
+var FileStore = require('../lib/session-file-store')(session);
+
+describe('store', function () {
+
+  describe('#constructor', function() {
+    it('should construct', function () {
+      var store = new FileStore({});
+    });
+  });
+
+});


### PR DESCRIPTION
Without the ./ in the require path, it results in `Error: Cannot find module 'session-file-helpers'`. I added a quick test too which failed without the fix.