### PR TITLE
Use Bagpipe to batch session reaping

### DIFF
--- a/lib/session-file-helpers.js
+++ b/lib/session-file-helpers.js
@@ -1,7 +1,8 @@
 var fs = require('fs-extra'),
   path = require('path'),
   retry = require('retry'),
-  childProcess = require('child_process');
+  childProcess = require('child_process'),
+  Bagpipe = require('bagpipe');
 
 var helpers = {
 
@@ -25,6 +26,7 @@ var helpers = {
       maxTimeout: options.maxTimeout || 100,
       filePattern: /\.json$/,
       reapInterval: options.reapInterval || 3600,
+      reapMaxConcurrent: options.reapMaxConcurrent || 10,
       reapAsync: options.reapAsync || false,
       reapSyncFallback: options.reapSyncFallback || false,
       logFn: options.logFn || console.log,
@@ -75,16 +77,21 @@ var helpers = {
       if (err) return callback(err);
       if (files.length === 0) return callback();
 
+      var bagpipe = new Bagpipe(options.reapMaxConcurrent);
+
       var errors = [];
       files.forEach(function (file, i) {
-        helpers.destroyIfExpired(helpers.sessionId(file), options, function (err) {
-          if (err) {
-            errors.push(err);
-          }
-          if (i >= files.length - 1) {
-            errors.length > 0 ? callback(errors) : callback();
-          }
-        });
+        bagpipe.push(helpers.destroyIfExpired,
+                     helpers.sessionId(file),
+                     options,
+                     function (err) {
+                       if (err) {
+                         errors.push(err);
+                       }
+                       if (i >= files.length - 1) {
+                         errors.length > 0 ? callback(errors) : callback();
+                       }
+                    });
       });
     });
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
+    "bagpipe": "^0.3.5",
     "fs-extra": "^0.18.2",
     "retry": "^0.6.1"
   },


### PR DESCRIPTION
This avoids EMFILE (too many open files) error if you have a lot
of session files.