### PR TITLE
change "new FileStore"  to "new FileStore({})"

### DIFF
--- a/examples/express-example/app.js
+++ b/examples/express-example/app.js
@@ -4,7 +4,7 @@ var session = require('express-session');
 var FileStore = require('session-file-store')(session);
 
 app.use(session({
-    store: new FileStore,
+    store: new FileStore({}),
     secret: 'keyboard cat',
     resave: true,
     saveUninitialized: true


### PR DESCRIPTION
when I use "new FileStore" to create a store in Express4(express-session),my website response very slow(while the route used "req.session") and the most strangest is node-inspector will restart autolly when I debug it.
After I deliver the empty option object "{}",the problem is solved.