### PR TITLE
`Touch` method improvement for session data rewrite prevention

### DIFF
--- a/lib/session-file-helpers.js
+++ b/lib/session-file-helpers.js
@@ -236,6 +236,32 @@ var helpers = {
   },
 
   /**
+   * Update the last access time and the cookie of given `session` associated with the given `sessionId` in session file.
+   * Note: Do not change any other session data.
+   *
+   * @param {String}   sessionId
+   * @param {Object}   session
+   * @param {Object}   options
+   * @param {Function} callback (optional)
+   *
+   * @api public
+   */
+  touch: function (sessionId, session, options, callback) {
+    helpers.get(sessionId, options, function(err, originalSession) {
+      if (err) {
+        callback(err, null);
+        return;
+      }
+      if (session.cookie) {
+        // Update cookie details
+        originalSession.cookie = session.cookie;
+      }
+      // Update `__lastAccess` property and save to store 
+      helpers.set(sessionId, originalSession, options, callback);
+    });
+  },
+    
+  /**
    * Attempts to unlink a given session by its id
    *
    * @param  {String}   sessionId   Files are serialized to disk by their sessionId

--- a/lib/session-file-store.js
+++ b/lib/session-file-store.js
@@ -70,10 +70,8 @@ module.exports = function (session) {
    *
    * @api public
    */
-
   FileStore.prototype.touch = function (sessionId, session, callback) {
-    // will update last access time
-    helpers.set(sessionId, session, this.options, callback);
+    helpers.touch(sessionId, session, this.options, callback);
   };
 
   /**

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -454,6 +454,47 @@ describe('helpers', function () {
     });
   });
 
+  describe('#touch', function () {
+    before(function (done) {
+      fs.emptyDir(SESSIONS_OPTIONS.path, done);
+    });
+
+    after(function (done) {
+      fs.remove(SESSIONS_OPTIONS.path, done);
+    });
+
+
+    it('should fails when no session file exists', function (done) {
+      var session = clone(SESSION);
+      helpers.touch('no_exists', session, SESSIONS_OPTIONS, function (err, json) {
+        expect(err)
+            .to.be.ok
+            .and.is.an('object')
+            .and.have.property('code', 'ENOENT');
+        expect(json).to.not.exist;
+        done();
+      });
+    });
+
+    it('should succeeds when valid session touched', function (done) {
+      var session = clone(SESSION);
+      session.__lastAccess = 0;
+      // first we create a session file in order to read a valid one later
+      helpers.set(SESSION_ID, session, SESSIONS_OPTIONS, function (err, json) {
+        expect(err).to.not.exist;
+
+        helpers.touch(SESSION_ID, session, SESSIONS_OPTIONS, function (err, json) {
+          expect(err).to.not.exist;
+          expect(json).to.be.ok;
+          expect(json).to.have.property('__lastAccess');
+          expect(json.__lastAccess).to.not.equal(SESSION.__lastAccess);
+          done();
+        });
+      });
+    });
+
+  });
+  
   describe('#destroy', function () {
     var SESSION_FILE = path.join(SESSIONS_OPTIONS.path, SESSION_ID + '.json');
 


### PR DESCRIPTION
**Issue:**

Race condition issue could cause "restore" of older version of session data.
Touch method saves data loaded on request start. But if there is some session edit on second parallel request, this edit can be rewritten/lost by `touch` method called in first request.


**Solution:**

If no session data edit (`touch` method called only), do not use data loaded on request start, but load the new one from file and edit `__lastAccess` and `cookie` details only.


**Example of issue:**

```
  TIME    ----->----->----->----->----->----->----->----->----->----->

Request 1   Start ==============> Process ==============> End
 (long    (session                                 (session touch
 polling)   load)                                   causes rollback
                                                      of logout)

Request 2              Start ==> Process ==> End
(short)               (session  (logout)   (session
                        load)                save)
```

