### PR TITLE
Use "cipheriv" for node 8 compability

### DIFF
--- a/lib/session-file-helpers.js
+++ b/lib/session-file-helpers.js
@@ -370,27 +370,43 @@ var helpers = {
   },
 
   encrypt: function (options, data, sessionId) {
-    var cipher = crypto.createCipher(helpers.encAlgorithm, options.keyFunction(options.secret, sessionId));
-    var crypted = cipher.update(data, options.encoding, options.encryptEncoding );
+    var prefix = 'IV;';
+    var key = options.keyFunction(options.secret, sessionId);
+    var hashedKey = crypto.createHash('sha256').update(key).digest();
+    var iv = crypto.randomBytes(16);
+    var cipher = crypto.createCipheriv(helpers.encAlgorithm, hashedKey, iv);
+    var crypted = cipher.update(data, options.encoding, options.encryptEncoding);
     var cryptedFinal = cipher.final(options.encryptEncoding);
     if ( typeof cryptedFinal === 'string' ) {
-      crypted += cryptedFinal;
+      return prefix + iv.toString(options.encryptEncoding || 'hex') + crypted + cryptedFinal;
     } else {
-      crypted = Buffer.concat([crypted, cryptedFinal], crypted.length + cryptedFinal.length);
+      return Buffer.concat([Buffer.from(prefix), iv, crypted, cryptedFinal], prefix.length + iv.length + crypted.length + cryptedFinal.length);
     }
-    return crypted;
   },
 
   decrypt: function (options, data, sessionId) {
-    var decipher = crypto.createDecipher(helpers.encAlgorithm, options.keyFunction(options.secret, sessionId));
-    var dec = decipher.update(data, options.encryptEncoding, options.encoding);
-    var decFinal = decipher.final(options.encoding);
-    if ( typeof decFinal === 'string' ) {
-      dec += decFinal;
+    var prefix = 'IV;';
+    var key = options.keyFunction(options.secret, sessionId);
+    var hashedKey = crypto.createHash('sha256').update(key).digest();
+    var hasIV = typeof data === 'string' ?
+      data.indexOf(prefix) === 0 :
+      Buffer.compare(data.slice(0, 3), Buffer.from(prefix)) === 0;
+    if (hasIV) {
+      var ivDataBuffer = typeof data === 'string' ? Buffer.from(data.slice(prefix.length), options.encryptEncoding || 'hex') : data.slice(prefix.length);
+      var iv = ivDataBuffer.slice(0, 16);
+      var decipher = crypto.createDecipheriv(helpers.encAlgorithm, hashedKey, iv);
+      var encryptedText = ivDataBuffer.slice(16);
     } else {
-      dec = Buffer.concat([dec, decFinal], dec.length + decFinal.length);
+      var decipher = crypto.createDecipher(helpers.encAlgorithm, options.keyFunction(options.secret, sessionId));
+      var encryptedText = data;
     }
-    return dec;
+    var dec = decipher.update(encryptedText, options.encryptEncoding, options.encoding);
+    var decFinal = decipher.final(options.encoding);
+    if (typeof decFinal === 'string') {
+      return dec + decFinal;
+    } else {
+      return Buffer.concat([dec, decFinal], dec.length + decFinal.length);
+    }
   }
 };
 


### PR DESCRIPTION
Fix for https://github.com/valery-barysok/session-file-store/issues/65

Create cipher with initialization vector to get rid of security warning with 'aes-256-ctr' mode.
PR provides support decryption with and without initialization vector. New encrypted data is prefixed with "IV;" to check does the encrypted data contain initialization vector or not when decrypting the data. Encryption key is hashed because key length has to be 32char/256bits.

PR is tested on Mac OS with Node.js 4, 6 and 8.