### PR TITLE
Add fileStoreOptions to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Due to express `>= 4` changes, we need to pass `express-session` to the function
 var session = require('express-session');
 var FileStore = require('session-file-store')(session);
 
+var fileStoreOptions = {};
+
 app.use(session({
-    store: new FileStore(options),
+    store: new FileStore(fileStoreOptions),
     secret: 'keyboard cat'
 }));
 ```


### PR DESCRIPTION
The basic usage example uses an `options` variable for initializing the `FileStore`, but `options` is not defined in the example. This change creates that variable so it's more easy to use with copy and paste.