### PR TITLE
fix: old store not removed after session.regenerate

### DIFF
--- a/lib/session-file-helpers.js
+++ b/lib/session-file-helpers.js
@@ -278,8 +278,12 @@ var helpers = {
    */
   destroy: function (sessionId, options, callback) {
     var sessionPath = helpers.sessionPath(options, sessionId);
-    fs.remove(sessionPath, callback || function () {
-    });
+    try {
+      fs.removeSync(sessionPath)
+      callback()
+    } catch (error) {
+      callback(error)
+    }
   },
 
   /**


### PR DESCRIPTION
This PR is related to [this bug](https://github.com/expressjs/session/issues/866)
When we call req.session.regenerate, old session store is not removed. fs-extra actually already removed that old session file, but somehow this store recreate the file. To fix this problem we just need change fs.remove to fs.removeSync to make sure session is already unlinked with old store before we regenerate it
